### PR TITLE
Added option to view single channel image

### DIFF
--- a/src/vesselness_image_viewer_node.cpp
+++ b/src/vesselness_image_viewer_node.cpp
@@ -118,9 +118,25 @@ public:
 
     if (msg->encoding.compare(std::string("32FC2")) == 0)
     {
-        ROS_INFO("Converting image");
+        ROS_INFO("Converting two channel image");
         Mat outputImage;
         convertSegmentImage(cv_ptr->image,outputImage);
+
+        ROS_INFO("Showing Image");
+        // Update GUI Window
+        cv::imshow(OPENCV_WINDOW, outputImage);
+        cv::waitKey(3);
+    }
+    else if (msg->encoding.compare(std::string("32FC1")) == 0)
+    {
+        ROS_INFO("Converting single channel image");
+        Mat outputImage;
+        
+        double maxVal(1);
+
+        minMaxLoc(cv_ptr->image,NULL,&maxVal, NULL, NULL);
+        ROS_INFO("%f",maxVal);
+        convertScaleAbs(cv_ptr->image,outputImage,(255.0/maxVal));
 
         ROS_INFO("Showing Image");
         // Update GUI Window


### PR DESCRIPTION
Working on develop branch of biocubed/vesselness_image_filter_cpu 

Made changes on vesselness_image_viewer_node
We added an option to view single channel images